### PR TITLE
Use correct binary on Windows OS

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -10,7 +10,8 @@ from os.path import exists
 
 
 def _flow_bin_path(path: str) -> str:
-    return join(path, "node_modules", ".bin", "flow")
+    binfile = "flow.cmd" if sublime.platform() == "windows" else "flow"
+    return join(path, "node_modules", ".bin", binfile)
 
 
 def _flow_config_path(path: str) -> str:


### PR DESCRIPTION
When using `LSP-flow` on Windows (10, but should be version independent), I get the following error on start:

![image](https://user-images.githubusercontent.com/47672946/120885552-f4cc1780-c5e9-11eb-96ac-fc469c49a910.png)

This is because it isn't using the correct binary/script. On Windows, the correct path is `node_modules/.bin/flow.cmd` instead of `node_modules/.bin/flow`.

This PR adds a check if the plugin is running on Windows and uses `flow.cmd` if it is. If not, it behaves just like it does now.