### PR TITLE
Recursively search up directory structure to find .flowconfig

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -39,7 +39,7 @@ class Flow(AbstractPlugin):
         folders: List[WorkspaceFolder],
         configuration: ClientConfig,
     ) -> Optional[str]:
-        path = _find_flow_root_path(initiating_view.file_name())
+        path = _find_flow_root_path(dirname(initiating_view.file_name()))
 
         if not path:
             return "no .flowconfig found in project or parent directories"

--- a/plugin.py
+++ b/plugin.py
@@ -5,8 +5,7 @@ from LSP.plugin.core.typing import Optional, List
 import sublime
 
 
-from os.path import join
-from os.path import exists
+from os.path import dirname, exists, join
 
 
 def _flow_bin_path(path: str) -> str:
@@ -18,22 +17,38 @@ def _flow_config_path(path: str) -> str:
     return join(path, ".flowconfig")
 
 
+def _find_flow_root_path(directory: str) -> Optional[str]:
+    if exists(_flow_config_path(directory)):
+        return directory
+    elif directory == dirname(directory):
+        return None
+    else:
+        return _find_flow_root_path(dirname(directory))
+
+
 class Flow(AbstractPlugin):
     @classmethod
     def name(cls) -> str:
         return cls.__name__.lower()
 
     @classmethod
-    def can_start(cls, _: sublime.Window, __: sublime.View,
-        folders: List[WorkspaceFolder], configuration: ClientConfig
+    def can_start(
+        cls,
+        _: sublime.Window,
+        initiating_view: sublime.View,
+        folders: List[WorkspaceFolder],
+        configuration: ClientConfig,
     ) -> Optional[str]:
-        if not folders:
-            return "need a folder"
-        path = folders[0].path
-        if not exists(_flow_config_path(path)):
-            return "no .flowconfig present in {}".format(path)
+        path = _find_flow_root_path(initiating_view.file_name())
+
+        if not path:
+            return "no .flowconfig found in project or parent directories"
+
         binpath = _flow_bin_path(path)
-        if not exists(_flow_bin_path(path)):
+        if not exists(binpath):
             return "no flow binary found (tried: {})".format(binpath)
+
+        folders.clear()
+        folders.append(WorkspaceFolder.from_path(path))
         configuration.command = [binpath, "lsp"]
         return None


### PR DESCRIPTION
Starting with the open file, recursively searches up the directory structure to find a `.flowconfig`, rather than only checking the workspace root. This is based on #3 (which unfortunately looks like it was abandoned) and incorporates the feedback from that PR. (I'm not sure why #3 had the `configuration.command` override in the `on_pre_start` because it seems to work fine keeping it in the `can_start`.)