### PR TITLE
Explicitly register and unregister the plugin

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,7 @@
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
+from LSP.plugin import register_plugin
+from LSP.plugin import unregister_plugin
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.typing import Optional, List
 import sublime
@@ -24,6 +26,14 @@ def _find_flow_root_path(directory: str) -> Optional[str]:
         return None
     else:
         return _find_flow_root_path(dirname(directory))
+
+
+def plugin_loaded() -> None:
+    register_plugin(Flow)
+
+
+def plugin_unloaded() -> None:
+    unregister_plugin(Flow)
 
 
 class Flow(AbstractPlugin):


### PR DESCRIPTION
While not registering explicitly works, it can cause issues, especially on upgrading package.